### PR TITLE
Use a pointer as list head

### DIFF
--- a/Programmentwurf/Simple_Linked_List/linkedListLib.c
+++ b/Programmentwurf/Simple_Linked_List/linkedListLib.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include "linkedListLib.h"
 
-void addListElem(listElement *start)
+listElement *addListElem(listElement *list)
 {
 
     listElement *new;
@@ -11,14 +11,8 @@ void addListElem(listElement *start)
     if (new == NULL)
     {
         printf("can't reserve storage.\n");
-        return;
+        return NULL;
     }
-
-    listElement *currElem = start;
-    while (currElem->nextElem != NULL)
-        currElem = currElem->nextElem; // get last elem in list
-    currElem->nextElem = new;          // add new to the end of list
-    new->nextElem = NULL;
 
     /* fill data in new element */
     printf("Please enter last name: \n");
@@ -27,31 +21,41 @@ void addListElem(listElement *start)
     scanf("%s", new->firstName);
     printf("Please enter age: \n");
     scanf("%d", &(new->age));
+
+    new->nextElem = NULL;
+
+    if(!list) return new;
+
+    listElement *currElem = list;
+    while (currElem->nextElem != NULL)
+        currElem = currElem->nextElem; // get last elem in list
+    currElem->nextElem = new;          // add new to the end of list
 }
 
-void printList(listElement *start)
+void printList(const listElement *list)
 {
 
-    if (start->nextElem == NULL)
+    if (list == NULL)
         printf("List is empty.\n");
     else
     {
         int i = 0;
-        listElement *currElem = start;
+        const listElement *currElem = list;
         printf("\ncurrent list:\n\n");
         do
         {
-            currElem = currElem->nextElem;
             printf("%d", i);
             i++;
             printf("\t last name: %s\n", currElem->lastName);
             printf("\t first name: %s\n", currElem->firstName);
             printf("\t age: %d\n", currElem->age);
-        } while (currElem->nextElem != NULL);
+
+            currElem = currElem->nextElem;
+        } while (currElem != NULL);
     }
 }
 
-void delListElem(listElement *start)
+listElement *delListElem(listElement *list)
 {
 
     /* YOUR CODE HERE */
@@ -60,7 +64,7 @@ void delListElem(listElement *start)
     printf("\n>> delListElem fcn is tbd.\n\n");
 }
 
-void delList(listElement *start)
+void delList(listElement *list)
 {
 
     /* YOUR CODE HERE */
@@ -69,11 +73,11 @@ void delList(listElement *start)
     printf("\n>> getLenOfList fcn is tbd.\n\n");
 }
 
-int getLenOfList(listElement *start)
+int getLenOfList(const listElement *list)
 { // we use this for save list fcn
 
     int counter = 0;
-    listElement *currElem = start;
+    const listElement *currElem = list;
     while (currElem->nextElem != NULL)
     { // get last elem in list
         currElem = currElem->nextElem;
@@ -82,7 +86,7 @@ int getLenOfList(listElement *start)
     return counter;
 }
 
-void saveList(listElement *start)
+void saveList(const listElement *list)
 {
 
     /* YOUR CODE HERE */
@@ -91,7 +95,7 @@ void saveList(listElement *start)
     printf("\n>> saveList fcn is tbd.\n\n");
 }
 
-void loadList(listElement *start)
+listElement *loadList(listElement *list)
 {
 
     /* YOUR CODE HERE */
@@ -100,16 +104,16 @@ void loadList(listElement *start)
     printf("\n>> loadList fcn is tbd.\n\n");
 
     printf("loading data will be append to current list...\n");
-    printList(start); // show loaded list
+    printList(list); // show loaded list
 }
 
-void exitFcn(listElement *start)
+void exitFcn(const listElement *list)
 {
 
     printf("\n>> exitFcn fcn is tbd.\n\n");
 }
 
-void sortList(listElement *start)
+listElement *sortList(listElement *list)
 {
 
     printf("\n>>sortList fcn is tbd.\n\n");

--- a/Programmentwurf/Simple_Linked_List/linkedListLib.h
+++ b/Programmentwurf/Simple_Linked_List/linkedListLib.h
@@ -26,9 +26,9 @@ typedef struct listElem listElement;
 
     \DESCRIPTION: adds new entity of listElement to current list
  
-    \param[in]  pointer to start element of current list              
+    \param[in]  pointer to list element of current list
 */
-void addListElem(listElement *);
+listElement *addListElem(listElement *list);
 
 /** 
     \FUNCTION: printList
@@ -39,9 +39,9 @@ void addListElem(listElement *);
 
     \DESCRIPTION: prints whole list to terminal
  
-    \param[in]  pointer to start element of current list              
+    \param[in]  pointer to list element of current list
 */
-void printList(listElement *);
+void printList(const listElement *list);
 
 /** 
     \FUNCTION: delListElem
@@ -54,7 +54,7 @@ void printList(listElement *);
  
     \param[in]  pointer to start element of current list              
 */
-void delListElem(listElement *);
+listElement *delListElem(listElement *list);
 
 /** 
     \FUNCTION: delList
@@ -78,11 +78,11 @@ void delList(listElement *);
 
     \DESCRIPTION: calculates the lenght of current list
  
-    \param[in]  pointer to start element of current list        
+    \param[in]  pointer to list element of current list
 
     \param[out] lenght of current list
 */
-int getLenOfList(listElement *);
+int getLenOfList(const listElement *list);
 
 /** 
     \FUNCTION: saveList
@@ -95,7 +95,7 @@ int getLenOfList(listElement *);
  
     \param[in]  pointer to start element of current list        
 */
-void saveList(listElement *);
+void saveList(const listElement *list);
 
 /** 
     \FUNCTION: loadList
@@ -108,7 +108,7 @@ void saveList(listElement *);
  
     \param[in]  pointer to start element of current list        
 */
-void loadList(listElement *);
+listElement *loadList(listElement *list);
 
 /** 
     \FUNCTION: exitFcn
@@ -121,7 +121,7 @@ void loadList(listElement *);
  
     \param[in]  pointer to start element of current list        
 */
-void exitFcn(listElement *);
+void exitFcn(const listElement *list);
 
 /** 
     \FUNCTION: sortList
@@ -134,7 +134,7 @@ void exitFcn(listElement *);
  
     \param[in]  pointer to start element of current list        
 */
-void sortList(listElement *);
+listElement *sortList(listElement *list);
 
 /** 
     \FUNCTION: stringToLower

--- a/Programmentwurf/Simple_Linked_List/main.c
+++ b/Programmentwurf/Simple_Linked_List/main.c
@@ -31,13 +31,7 @@
 **/
 int main(){
 
-    listElement *start;
-    start = (listElement *)malloc(sizeof(listElement));
-    if (start == NULL) {
-        printf("can't reserve storage.\n"); 
-        return -1;
-        }
-    start->nextElem = NULL;
+    listElement *list = NULL;
 
     int FLAGG = 1;
     while (FLAGG){
@@ -55,14 +49,14 @@ int main(){
 
 
         switch (FLAGG){
-            case 1: printList(start); break;
-            case 2: addListElem(start); break;
-            case 3: delListElem(start); break;
-            case 4: delList(start); break;
-			case 5: saveList(start); break;
-			case 6: loadList(start); break;
-            case 7: sortList(start); break;
-            case 0: FLAGG = 0; exitFcn(start); break;
+            case 1: printList(list); break;
+            case 2: list = addListElem(list); break;
+            case 3: list = delListElem(list); break;
+            case 4: delList(list); list = NULL; break;
+			case 5: saveList(list); break;
+			case 6: list = loadList(list); break;
+            case 7: list = sortList(list); break;
+            case 0: FLAGG = 0; exitFcn(list); break;
             default: printf("invalid choice\n"); break;
         }
     }


### PR DESCRIPTION
I could not find any possible reason why the head of the linked list should be anything other than a pointer. Especially when the only relevant information inside the  `listElement` struct is the pointer. 

You could directly pass a pointer to the head pointer around and modify the head pointer when required, or simply return a pointer to the new head, like in this PR. The latter might be more understandable for newcomers, who just getting started with programming.