### PR TITLE
Mass damper simulation template clean up

### DIFF
--- a/Programmentwurf/Mass_Spring_Damper/eulerLib.c
+++ b/Programmentwurf/Mass_Spring_Damper/eulerLib.c
@@ -1,19 +1,16 @@
 #include <stdio.h>
-#include <stdlib.h>
 #include <math.h>
 #include "eulerLib.h"
 
-#define NUM_OF_STATES 2
-
-void massSpringDamperCalculation(double *rhs, double *y)
+SimulationState massSpringDamperCalculation(SimulationState state, double duration)
 { // mass spring damper
 
     double m = 1.0;  // mass of object
     double c = 5;    // spring constant
     double d = 0.25; // damper constant
 
-    double x = y[0]; // position
-    double v = y[1]; // speed
+    double x = state.position;
+    double v = state.velocity;
 
     /*calc derivatives and store in rhs*/
 
@@ -74,29 +71,22 @@ SimulationHandle getHandle()
     /* ---------------*/
 }
 
-void calculateSimulation(SimulationHandle *handle)
+void calculateSimulation(const SimulationHandle *handle)
 { // this is called only once
-    int numOfStates = handle->numOfStates;
     int integratorSteps = (int)ceil(handle->duration / handle->stepSize);
 
     /*write init states*/
-    for (int i = 0; i < numOfStates; i++)
+    for (int i = 0; i < handle->stateCount; i++)
     {
-        handle->stateVec[i] = handle->stateVecInit[i];
+        handle->states[i] = handle->initialState;
     }
+
     for (int i = 0; i < integratorSteps; i++)
     {
         /*get derivatives*/
 
         /* YOUR CODE HERE */
         /* ---------------*/
-        for (int j = 0; j < numOfStates; j++)
-        {
-            /*euler step*/
-
-            /* YOUR CODE HERE */
-            /* ---------------*/
-        }
     }
 }
 

--- a/Programmentwurf/Mass_Spring_Damper/eulerLib.c
+++ b/Programmentwurf/Mass_Spring_Damper/eulerLib.c
@@ -75,12 +75,6 @@ void calculateSimulation(const SimulationHandle *handle)
 { // this is called only once
     int integratorSteps = (int)ceil(handle->duration / handle->stepSize);
 
-    /*write init states*/
-    for (int i = 0; i < handle->stateCount; i++)
-    {
-        handle->states[i] = handle->initialState;
-    }
-
     for (int i = 0; i < integratorSteps; i++)
     {
         /*get derivatives*/

--- a/Programmentwurf/Mass_Spring_Damper/eulerLib.c
+++ b/Programmentwurf/Mass_Spring_Damper/eulerLib.c
@@ -3,13 +3,13 @@
 #include <math.h>
 #include "eulerLib.h"
 
-#define NUMOFSTATES 2
+#define NUM_OF_STATES 2
 
-void RHS_MSD(double *rhs, double *y)
+void massSpringDamperCalculation(double *rhs, double *y)
 { // mass spring damper
 
     double m = 1.0;  // mass of object
-    double c = 5;    // feder constant
+    double c = 5;    // spring constant
     double d = 0.25; // damper constant
 
     double x = y[0]; // position
@@ -21,7 +21,7 @@ void RHS_MSD(double *rhs, double *y)
     /* ---------------*/
 }
 
-void eulerSettings_MSD(simHandle *handle)
+void initHandle(SimulationHandle *)
 {
 
     /*num of states*/
@@ -39,14 +39,14 @@ void eulerSettings_MSD(simHandle *handle)
     /* YOUR CODE HERE */
     /* ---------------*/
 
-    /*get user defined Simtime*/
-    printf("Simtime (in s): \n");
+    /*get user defined simulation time*/
+    printf("Simulation time (in s): \n");
 
     /* YOUR CODE HERE */
     /* ---------------*/
 
-    /*get user defined StepSize*/
-    printf("StepSize (in s): \n");
+    /*get user defined step size*/
+    printf("Step size (in s): \n");
 
     /* YOUR CODE HERE */
     /* ---------------*/
@@ -74,10 +74,10 @@ void eulerSettings_MSD(simHandle *handle)
     /* ---------------*/
 }
 
-void eulerForward(simHandle *handle)
+void calculateSimulation(SimulationHandle *handle)
 { // this is called only once
     int numOfStates = handle->numOfStates;
-    int integratorSteps = (int)ceil(handle->simTime / handle->stepSize);
+    int integratorSteps = (int)ceil(handle->duration / handle->stepSize);
 
     /*write init states*/
     for (int i = 0; i < numOfStates; i++)
@@ -100,7 +100,7 @@ void eulerForward(simHandle *handle)
     }
 }
 
-void showResults_MSD(simHandle *handle)
+void plotSimulation(SimulationHandle *)
 {
 
     /*print data to text file*/

--- a/Programmentwurf/Mass_Spring_Damper/eulerLib.c
+++ b/Programmentwurf/Mass_Spring_Damper/eulerLib.c
@@ -21,7 +21,7 @@ void massSpringDamperCalculation(double *rhs, double *y)
     /* ---------------*/
 }
 
-void initHandle(SimulationHandle *)
+SimulationHandle getHandle()
 {
 
     /*num of states*/

--- a/Programmentwurf/Mass_Spring_Damper/eulerLib.h
+++ b/Programmentwurf/Mass_Spring_Damper/eulerLib.h
@@ -1,5 +1,7 @@
 #ifndef EULERLIB_H_
 #define EULERLIB_H_
+
+#include "stdlib.h"
 /** 
     \STRUCT: SimulationHandle
  
@@ -25,14 +27,17 @@
 
 */
 
-typedef void(*SimulationCalculation)(double *, double*);
+typedef struct {
+    double position;
+    double velocity;
+} SimulationState;
+
+typedef SimulationState (*SimulationCalculation)(SimulationState state);
 
 typedef struct {
     SimulationCalculation function;
-    double* stateVec;
-    double* stateVecInit;
-    double* derivationStateVec;
-    int numOfStates;
+    SimulationState *states;
+    SimulationState initialState;
     double stepSize;
     double duration;
 } SimulationHandle;
@@ -50,7 +55,7 @@ typedef struct {
 
     \param[in]  reference to storage vector for derivatives [out]
 */
-void massSpringDamperCalculation(double*, double*);
+SimulationState massSpringDamperCalculation(SimulationState state, double duration);
 
 /** 
     \FUNCTION: calculateSimulation
@@ -64,7 +69,7 @@ void massSpringDamperCalculation(double*, double*);
     \param[in]  reference to SimulationHandle
 
 */
-void calculateSimulation(SimulationHandle*);
+void calculateSimulation(const SimulationHandle *handle);
 
 /** 
     \FUNCTION: plotSimulation

--- a/Programmentwurf/Mass_Spring_Damper/eulerLib.h
+++ b/Programmentwurf/Mass_Spring_Damper/eulerLib.h
@@ -9,7 +9,7 @@
 
     \DESCRIPTION: definition of handle to simulate first order ode-system as struct
 
-    \CONTAINS:  [void* f] rhs-function
+    \CONTAINS:  [void* function] rhs-function
 
                 [double* stateVec] states-array for all timesteps (t_0 ... t_end)
 
@@ -35,8 +35,7 @@ typedef struct {
     int numOfStates;
     double stepSize;
     double duration;
-};
-typedef struct SimHandle SimulationHandle;
+} SimulationHandle;
 
 /** 
     \FUNCTION: massSpringDamperCalculation
@@ -82,7 +81,7 @@ void calculateSimulation(SimulationHandle*);
 void plotSimulation(SimulationHandle*);
 
 /** 
-    \FUNCTION: initHandle
+    \FUNCTION: getHandle
  
     \AUTHOR: jannik wiessler
 
@@ -93,6 +92,6 @@ void plotSimulation(SimulationHandle*);
     \param[in]  reference to SimulationHandle
 
 */
-void initHandle(SimulationHandle*);
+SimulationHandle getHandle();
 
 #endif

--- a/Programmentwurf/Mass_Spring_Damper/eulerLib.h
+++ b/Programmentwurf/Mass_Spring_Damper/eulerLib.h
@@ -37,7 +37,6 @@ typedef SimulationState (*SimulationCalculation)(SimulationState state);
 typedef struct {
     SimulationCalculation function;
     SimulationState *states;
-    SimulationState initialState;
     double stepSize;
     double duration;
 } SimulationHandle;

--- a/Programmentwurf/Mass_Spring_Damper/eulerLib.h
+++ b/Programmentwurf/Mass_Spring_Damper/eulerLib.h
@@ -1,7 +1,7 @@
 #ifndef EULERLIB_H_
 #define EULERLIB_H_
 /** 
-    \STRUCT: simHandle
+    \STRUCT: SimulationHandle
  
     \AUTHOR: jannik wiessler
 
@@ -15,28 +15,31 @@
 
                 [double* stateVecInit] states-array with initial states (t = 0)
 
-                [double* derivStateVec] derivative-array for all timesteps (t_0 ... t_end)
+                [double* derivationStateVec] derivative-array for all timesteps (t_0 ... t_end)
 
                 [int numOfStates]: number of states in ode-system (two for mass-spring-damper-system)
 
                 [double stepSize]: timestepsize in seconds seconds for explicit euler method
 
-                [double simTime]: simTime in seconds for explicit euler method
+                [double simTime]: duration in seconds for explicit euler method
 
 */
-struct SimHandle {
-    void(*f)(double*, double*);
+
+typedef void(*SimulationCalculation)(double *, double*);
+
+typedef struct {
+    SimulationCalculation function;
     double* stateVec;
     double* stateVecInit;
-    double* derivStateVec;
+    double* derivationStateVec;
     int numOfStates;
     double stepSize;
-    double simTime;
+    double duration;
 };
-typedef struct SimHandle simHandle;
+typedef struct SimHandle SimulationHandle;
 
 /** 
-    \FUNCTION: RHS_MSD
+    \FUNCTION: massSpringDamperCalculation
  
     \AUTHOR: jannik wiessler
 
@@ -48,10 +51,10 @@ typedef struct SimHandle simHandle;
 
     \param[in]  reference to storage vector for derivatives [out]
 */
-void RHS_MSD(double*, double*);
+void massSpringDamperCalculation(double*, double*);
 
 /** 
-    \FUNCTION: eulerForward
+    \FUNCTION: calculateSimulation
  
     \AUTHOR: jannik wiessler
 
@@ -59,13 +62,13 @@ void RHS_MSD(double*, double*);
 
     \DESCRIPTION: explicit euler function to solve first order ode-system
  
-    \param[in]  reference to simHandle 
+    \param[in]  reference to SimulationHandle
 
 */
-void eulerForward(simHandle*);
+void calculateSimulation(SimulationHandle*);
 
 /** 
-    \FUNCTION: showResults_MSD
+    \FUNCTION: plotSimulation
  
     \AUTHOR: jannik wiessler
 
@@ -73,23 +76,23 @@ void eulerForward(simHandle*);
 
     \DESCRIPTION: visualize the results of given ode-system solved by given used sim method
  
-    \param[in]  reference to simHandle 
+    \param[in]  reference to SimulationHandle
 
 */
-void showResults_MSD(simHandle*);
+void plotSimulation(SimulationHandle*);
 
 /** 
-    \FUNCTION: eulerSettings_MSD
+    \FUNCTION: initHandle
  
     \AUTHOR: jannik wiessler
 
     \DATE: 2021-01-10
 
-    \DESCRIPTION: initialize simHandle by user defined specs
+    \DESCRIPTION: initialize SimulationHandle by user defined specs
  
-    \param[in]  reference to simHandle 
+    \param[in]  reference to SimulationHandle
 
 */
-void eulerSettings_MSD(simHandle*);
+void initHandle(SimulationHandle*);
 
 #endif

--- a/Programmentwurf/Mass_Spring_Damper/main.c
+++ b/Programmentwurf/Mass_Spring_Damper/main.c
@@ -1,6 +1,3 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
 #include "eulerLib.h"
 /*******************************************************
 * NAME: main.c (main) 
@@ -22,11 +19,10 @@
 int main()
 {
 
-    simHandle myHandle;
-    simHandle *handle = &myHandle;
-    eulerSettings_MSD(handle);
-    eulerForward(handle);
-    showResults_MSD(handle);
+    SimulationHandle handle;
+    initHandle(&handle);
+    calculateSimulation(&handle);
+    plotSimulation(&handle);
 
     return 0;
 }

--- a/Programmentwurf/Mass_Spring_Damper/main.c
+++ b/Programmentwurf/Mass_Spring_Damper/main.c
@@ -19,8 +19,7 @@
 int main()
 {
 
-    SimulationHandle handle;
-    initHandle(&handle);
+    SimulationHandle handle = getHandle();
     calculateSimulation(&handle);
     plotSimulation(&handle);
 


### PR DESCRIPTION
Like mentioned in issue #4, following clean code makes the templates more understandable. 

Using arrays to represent a fixed value pair makes any implementation more prone to mistakes. As it is right know, more time is spend trying to figure out what the templates intends to do and how it intends to do something than any potential time saved using it.

The commit messages contain further information about the changes if necessary.  